### PR TITLE
api utils usage fix:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ booklogr
 instance
 book.db
 .vscode
+
+data

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,8 @@
     "build": "cross-env VITE_APP_VERSION=$npm_package_version vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "test": "node --test tests/**/*.test.js",
+    "test:watch": "node --test --watch tests/**/*.test.js",
     "postinstall": "flowbite-react patch"
   },
   "dependencies": {

--- a/web/src/services/api.utils.js
+++ b/web/src/services/api.utils.js
@@ -1,0 +1,11 @@
+export const createAPIUrl = (baseUrl) => (endpoint) => {
+    let apiEndpoint = baseUrl;
+    // trim trailing slash if it exists
+    if (apiEndpoint.endsWith("/")) {
+        apiEndpoint = apiEndpoint.slice(0, -1);
+    }
+
+    return new URL(endpoint, apiEndpoint).toString();
+};
+
+export const getAPIUrl = createAPIUrl(import.meta.env?.VITE_API_ENDPOINT || 'http://localhost:5000');

--- a/web/src/services/api.utils.jsx
+++ b/web/src/services/api.utils.jsx
@@ -1,3 +1,0 @@
-export const getAPIUrl = (endpoint) => {
-    return new URL(endpoint, import.meta.env.VITE_API_ENDPOINT).toString();
-};

--- a/web/src/services/auth.service.jsx
+++ b/web/src/services/auth.service.jsx
@@ -13,7 +13,7 @@ axios.interceptors.response.use((response) => {
 });
 
 const register = (email, name, password) => {
-    return axios.post(getAPIUrl("/v1/register"), {
+    return axios.post(getAPIUrl("v1/register"), {
         email,
         name,
         password,
@@ -22,7 +22,7 @@ const register = (email, name, password) => {
 
 const login = (email, password) => {
     return axios
-        .post(getAPIUrl("/v1/login"), {
+        .post(getAPIUrl("v1/login"), {
             email,
             password,
         })
@@ -36,7 +36,7 @@ const login = (email, password) => {
 };
 
 const loginGoogle = (code) => {
-    return axios.post(getAPIUrl("/v1/authorize/google"), {code}).then((response) => {
+    return axios.post(getAPIUrl("v1/authorize/google"), {code}).then((response) => {
         if (response.data.access_token) {
             localStorage.setItem("auth_user", JSON.stringify(response.data));
         }
@@ -54,7 +54,7 @@ const getCurrentUser = () => {
 };
 
 const verify = (email, code) => {
-    return axios.post(getAPIUrl("/v1/verify"), {
+    return axios.post(getAPIUrl("v1/verify"), {
         email,
         code,
     });

--- a/web/tests/services/api.utils.test.js
+++ b/web/tests/services/api.utils.test.js
@@ -1,0 +1,35 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { createAPIUrl } from '../../src/services/api.utils.js';
+
+describe('api.utils', () => {
+  test('createAPIUrl should construct correct URL with plain endpoint', () => {
+    const getAPIUrl = createAPIUrl('https://api.example.com');
+    const result = getAPIUrl('/books');
+    assert.strictEqual(result, 'https://api.example.com/books');
+  });
+
+  test('createAPIUrl should handle trailing slash in API endpoint', () => {
+    const getAPIUrl = createAPIUrl('https://api.example.com/');
+    const result = getAPIUrl('/books');
+    assert.strictEqual(result, 'https://api.example.com/books');
+  });
+
+  test('createAPIUrl should handle endpoint without leading slash', () => {
+    const getAPIUrl = createAPIUrl('https://api.example.com');
+    const result = getAPIUrl('books');
+    assert.strictEqual(result, 'https://api.example.com/books');
+  });
+
+  test('createAPIUrl should handle absolute endpoint paths', () => {
+    const getAPIUrl = createAPIUrl('https://api.example.com/v1/');
+    const result = getAPIUrl('/books/123');
+    assert.strictEqual(result, 'https://api.example.com/books/123');
+  });
+
+  test('createAPIUrl should handle relative endpoint paths', () => {
+    const getAPIUrl = createAPIUrl('https://api.example.com/api/v2/');
+    const result = getAPIUrl('users/profile');
+    assert.strictEqual(result, 'https://api.example.com/api/users/profile');
+  });
+});

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -6,4 +6,10 @@ import flowbiteReact from "flowbite-react/plugin/vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), flowbiteReact()],
+  build: {
+    rollupOptions: {
+      // exclude tests from build
+      external: (id) => id.includes('/tests/'),
+    },
+  },
 });


### PR DESCRIPTION
- usage of getAPIUrl is consistent in auth.service.jsx with other usage in the codebase to avoid double // - in paths that cause auth related requests to fail
- api.utils.jsx to just .js file since it does not contain any jsx
- trailing / in base apis are ignored
- small refactor to getAPIUrl to make it slightly more testable
- basic unit test for api.utils.js

Basic testing setup
- package.json contains commands for running unit tests using node built in testing framework


Tested to run this app and seemed like there was mismatch with how the API url is constructed, tested the fix quickly so that the registration works with the change.

Also added a basic unit test.
Added to gitignore also the data folder that the docker compose create for the sqlite volume when running locally.