### PR TITLE
Use the note icon in the notes empty state

### DIFF
--- a/web/src/components/NotesView.jsx
+++ b/web/src/components/NotesView.jsx
@@ -91,7 +91,7 @@ function NotesView({id, allowEditing, open, setOpen, overrideNotes}) {
                             {notes?.length <= 0 &&
                                 <div className="col-span-3">
                                     <div className="grid grid-cols-1 grid-rows-3 place-items-center justify-center items-center text-center">
-                                        <RiDoubleQuotesR size={96} className="dark:text-white"/>
+                                        <RiStickyNoteLine size={96} className="dark:text-white"/>
                                         <div className="format lg:format-lg dark:format-invert">
                                             <h2>{t("notes.no_notes_error.title")}</h2>
                                             <p>{t("notes.no_notes_error.description")}</p>


### PR DESCRIPTION
Fixes #99.

This swaps the empty-state icon in the Notes tab from `RiDoubleQuotesR` to `RiStickyNoteLine`, matching the tab label and the rest of the notes UI.

Verification:
- `npm ci`
- `npm run build`
- `git diff --check`

Note: `npm run lint` currently stops before linting project files because ESLint 9 expects a flat `eslint.config.*` file while this repo still has `.eslintrc.cjs`. I left that toolchain migration out of this icon fix.

Small paid-fix note: if this quick UI fix saves you time and you want to settle it directly, the optional $10 checkout is here: https://nicdunz.gumroad.com/l/tiny-codex-teardown-direct?wanted=true. No pressure either way.