### PR TITLE
Fix: add missing dark mode class

### DIFF
--- a/web/src/components/Library/BookRating.jsx
+++ b/web/src/components/Library/BookRating.jsx
@@ -54,7 +54,7 @@ function BookRating(props) {
 
     const rating = () => {
         return (
-            <Rating size={props.size} onClick={() => handleOpenModal()} className={`${!props.disableGiveRating ? "hover:bg-gray-100 hover:cursor-pointer":""} w-fit`}>
+            <Rating size={props.size} onClick={() => handleOpenModal()} className={`${!props.disableGiveRating ? "hover:bg-gray-100 dark:hover:bg-gray-600 hover:cursor-pointer":""} w-fit`}>
                 <RatingStar filled={Math.floor(props.rating) >= 1 ? true : false} />
                 <RatingStar filled={Math.floor(props.rating) >= 2 ? true : false} />
                 <RatingStar filled={Math.floor(props.rating) >= 3 ? true : false} />

--- a/web/src/pages/BookDetails.jsx
+++ b/web/src/pages/BookDetails.jsx
@@ -89,7 +89,7 @@ function BookDetails() {
                 <div>
                     <article className="format dark:format-invert">
                         <h2 className="mb-2">{data?.title || <Skeleton />}</h2>
-                        <h3 className="text-xl font-medium text-gray-900 tracking-tight">{subtitle || <Skeleton />}</h3>
+                        <h3 className="text-xl font-medium text-gray-900 dark:text-gray-100 tracking-tight">{subtitle || <Skeleton />}</h3>
                         {author ? (
                             <p className="lead">{t("book.by_author", { author: author })}</p>
                         ) : (


### PR DESCRIPTION
Add missing dark styling 

### book subtitle in book details 
Before
<img width="505" height="312" alt="image" src="https://github.com/user-attachments/assets/372aff23-ef60-4b5e-9ebe-a25bfd2ba98c" />

After
<img width="435" height="298" alt="image" src="https://github.com/user-attachments/assets/7711f492-7d4b-4f05-b712-8d2c9263a161" />

### Rating
Before
<img width="365" height="162" alt="image" src="https://github.com/user-attachments/assets/26a98ab5-2ae4-4c04-b4ed-786ba3d307c2" />


After
<img width="360" height="162" alt="image" src="https://github.com/user-attachments/assets/58d15c17-be22-4695-9555-1cb14379e2ab" />
