### PR TITLE
fix: resolve parameter validation logic and rating bounds checking bugs

### DIFF
--- a/api/auth/auth_route.py
+++ b/api/auth/auth_route.py
@@ -50,7 +50,7 @@ def register():
       500:
         description: Internal server error.
     """
-    if not "email" or not "password" or not "name" in request.json:
+    if not request.json or "email" not in request.json or "password" not in request.json or "name" not in request.json:
         abort(422)
     if User.find_by_email(request.json["email"]):
         return jsonify({'message': 'Email {} is already in use'.format(request.json["email"])}), 409
@@ -107,7 +107,7 @@ def verify():
       500:
         description: Internal server error.
     """
-    if not "email" or not "code" in request.json:
+    if not request.json or "email" not in request.json or "code" not in request.json:
         abort(422)
 
     current_user = User.find_by_email(request.json["email"])
@@ -160,7 +160,7 @@ def login():
       404:
         description: Missing email or password.
     """
-    if not "email" or not "password" in request.json:
+    if not request.json or "email" not in request.json or "password" not in request.json:
         abort(422)
     current_user = User.find_by_email(request.json["email"])
     if not current_user:
@@ -302,7 +302,7 @@ def change_email():
     requestBody:
       required: true
       content:
-        application/json:
+        application/json: 
           schema:
             type: object
             required: [new_email]

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -457,12 +457,14 @@ def edit_book(id):
                 return jsonify({"error": "Unprocessable entity", "message": "Can't process change. Status needs to be either 'Currently reading', 'To be read' or 'Read' (case sensitive)"}), 422 
 
         if "rating" in request.json:
-            if 0 <= float(request.json["rating"]) <= 5:
-                book.rating = request.json["rating"]
-            elif int(request.json["rating"]) > 5:
-                return jsonify({"error": "Unprocessable entity", "message": "Can't process change. Rating can't be more than 5."}), 422 
-            elif int(request.json["rating"]) < 0:
-                return jsonify({"error": "Unprocessable entity", "message": "Can't process change. Rating can't be less than 0."}), 422
+            try:
+                rating_val = float(request.json["rating"])
+                if 0 <= rating_val <= 5:
+                    book.rating = rating_val
+                else:
+                    return jsonify({"error": "Unprocessable entity", "message": "Can't process change. Rating must be between 0 and 5."}), 422
+            except (ValueError, TypeError):
+                return jsonify({"error": "Unprocessable entity", "message": "Can't process change. Rating must be a number."}), 422
         if "title" in request.json:
             book.title = request.json["title"]
         if "author" in request.json:
@@ -605,7 +607,7 @@ def add_book_note(id):
     if "quote_page" in request.json:
         page = request.json["quote_page"]
     if "visibility" in request.json:
-        if "hidden" or "public" in request.json["visibility"]:
+        if request.json["visibility"] in ("hidden", "public"):
           visibility = request.json["visibility"]
         else:
             return jsonify({

--- a/api/routes/notes.py
+++ b/api/routes/notes.py
@@ -86,7 +86,13 @@ def edit_note(id):
     note = Notes.query.join(Books, Books.id==Notes.book_id).filter(Books.owner_id==claim_id, Notes.id==id).first()
     if request.json:
         if "visibility" in request.json:
-            note.visibility = request.json["visibility"]
+            if request.json["visibility"] in ("hidden", "public"):
+                note.visibility = request.json["visibility"]
+            else:
+                return jsonify({
+                    "error": "Invalid visibility",
+                    "message": "The supplied visibility is invalid. It can be either hidden or public."
+                }), 422
         if "content" in request.json:
             note.content = request.json["content"]
         if "quote_page" in request.json:


### PR DESCRIPTION
This change fixes multiple validation bugs in authentication, books, and notes routes. Specifically, (1) it corrects the boolean evaluation bug in registration, verification, and login endpoints where checks like `not 'email' or not 'password' or not 'name' in request.json` only validated the last variable due to operator precedence, potentially causing unhandled KeyErrors. (2) It fixes rating validation in `edit_book` where float values like `5.5` or `-0.5` could bypass boundary checks and get processed or ignored incorrectly instead of returning a 422 error. (3) It fixes note visibility checks in book notes creation where the expression `if 'hidden' or 'public' in ...` was always truthy, and adds note visibility validation to the note edit route to maintain consistency and prevent database pollution with invalid values.