### PR TITLE
fix: fix order by created_on field

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, request, jsonify
-from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
 from api.models import Books, BooksSchema, NotesSchema, Notes, UserSettings, BooksStatusSchema, Profile, ReadingSessions, ReadingSessionsSchema, db
 from api.decorators import required_params, auth_required
 from api.routes.tasks import _create_task
@@ -217,8 +216,8 @@ def get_books():
           200:
             description: Returns books in list
     """
-    sort_fields = {"progress", "created_on", "title", "author", "rating", "reading_status", "isbn"}
-    order_fields = {"asc", "desc"}
+    SORT_FIELDS = {"progress", "created_on", "title", "author", "rating", "reading_status", "isbn"}
+    ORDER_FIELDS = {"asc", "desc"}
 
     limit = 25
     offset = request.args.get('offset', 1, type=int)
@@ -230,37 +229,37 @@ def get_books():
     sort_by = request.args.get("sort_by", "title")
     order = request.args.get("order", "asc")
 
-    if sort_by not in sort_fields:
+    if sort_by not in SORT_FIELDS:
       return jsonify({
                   'error': 'Invalid sort field',
                   'message': 'Sort can be only one of the following fields: progress, created_on, title, author, rating, reading_status, isbn'
               }), 400
     
-    if order not in order_fields:
+    if order not in ORDER_FIELDS:
       return jsonify({
                   'error': 'Invalid order field',
                   'message': 'Order can be only one of the following fields: asc, desc'
               }), 400
-    
   
     books_schema = BooksSchema(many=True)
-    books = Books.query.filter(Books.owner_id == claim_id)
+    books_query = Books.query.filter(Books.owner_id == claim_id)
 
     if query_status:
-        books = books.filter(Books.reading_status==query_status)
+        books_query = books_query.filter(Books.reading_status==query_status)
     
-    if sort_by in sort_fields:
-        if sort_by == "progress":
-          progress_calc = (Books.current_page * 100.0 / Books.total_pages).label('progress')
-          if order == "asc":
-            books = books.order_by(progress_calc.asc()).paginate(page=offset, per_page=limit, error_out=False)
-          else:
-              books = books.order_by(progress_calc.desc()).paginate(page=offset, per_page=limit, error_out=False)
-        else:
-          if order == "asc":
-            books = books.order_by(func.lower(getattr(Books, sort_by)).asc()).paginate(page=offset, per_page=limit, error_out=False)
-          else:
-            books = books.order_by(func.lower(getattr(Books, sort_by)).desc()).paginate(page=offset, per_page=limit, error_out=False)
+    if sort_by == "progress":
+      sort_field = (Books.current_page * 100.0 / Books.total_pages).label('progress')
+    elif sort_by == "created_on":
+      sort_field = Books.created_on
+    else:
+      sort_field = func.lower(getattr(Books, sort_by))
+
+    if order == "asc":
+      books_query = books_query.order_by(sort_field.asc())
+    else:    
+     books_query = books_query.order_by(sort_field.desc())
+
+    books = books_query.paginate(page=offset, per_page=limit, error_out=False)
 
     return jsonify({"items": books_schema.dump(books.items), "meta": {
             "page": books.page,

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
 from api.models import Books, BooksSchema, NotesSchema, Notes, UserSettings, BooksStatusSchema, Profile, ReadingSessions, ReadingSessionsSchema, db
 from api.decorators import required_params, auth_required
 from api.routes.tasks import _create_task
@@ -242,10 +243,10 @@ def get_books():
               }), 400
   
     books_schema = BooksSchema(many=True)
-    books_query = Books.query.filter(Books.owner_id == claim_id)
+    books = Books.query.filter(Books.owner_id == claim_id)
 
     if query_status:
-        books_query = books_query.filter(Books.reading_status==query_status)
+        books = books.filter(Books.reading_status==query_status)
     
     if sort_by == "progress":
       sort_field = (Books.current_page * 100.0 / Books.total_pages).label('progress')
@@ -255,11 +256,11 @@ def get_books():
       sort_field = func.lower(getattr(Books, sort_by))
 
     if order == "asc":
-      books_query = books_query.order_by(sort_field.asc())
+      books = books.order_by(sort_field.asc())
     else:    
-     books_query = books_query.order_by(sort_field.desc())
+     books = books.order_by(sort_field.desc())
 
-    books = books_query.paginate(page=offset, per_page=limit, error_out=False)
+    books = books.paginate(page=offset, per_page=limit, error_out=False)
 
     return jsonify({"items": books_schema.dump(books.items), "meta": {
             "page": books.page,


### PR DESCRIPTION
Sorting by created_on give me the following error

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedFunction) function lower(timestamp without time zone) does not exist
LINE 3: ... AND books.reading_status = 'To be read' ORDER BY lower(book...
                                                             ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

[SQL: SELECT books.id AS books_id, books.title AS books_title, books.isbn AS books_isbn, books.description AS books_description, books.author AS books_author, books.reading_status AS books_reading_status, books.current_page AS books_current_page, books.total_pages AS books_total_pages, books.rating AS books_rating, books.owner_id AS books_owner_id, books.created_on AS books_created_on 
FROM books 
WHERE books.owner_id = %(owner_id_1)s AND books.reading_status = %(reading_status_1)s ORDER BY lower(books.created_on) ASC 
 LIMIT %(param_1)s OFFSET %(param_2)s]
[parameters: {'owner_id_1': 1, 'reading_status_1': 'To be read', 'param_1': 25, 'param_2': 0}]
(Background on this error at: https://sqlalche.me/e/20/f405)
```
The fix handle created_on with a specific case where no lower is applied

This PR try to avoid duplication and clean (remove unused imports, constant in UPPERCASE, ..)