### PR TITLE
fix: pass sort, order and offset when all tab

### DIFF
--- a/web/src/services/books.service.jsx
+++ b/web/src/services/books.service.jsx
@@ -11,13 +11,14 @@ const get_isbn = (isbn) => {
 }
 
 const get = (status, sort, order, page) => {
-    if (status) {
-        return axios.get(getAPIUrl(`v1/books?status=${status}&sort_by=${sort}&order=${order}&offset=${page}`), { headers: authHeader() })
-
-    } else {
-        return axios.get(getAPIUrl("v1/books"), { headers: authHeader() })
-
-    }
+    var params = {
+        status,
+        sort_by: sort,
+        order,
+        offset: page
+    };
+    
+    return axios.get(getAPIUrl(`v1/books`),  { headers: authHeader(), params: params });
 }
 
 const edit = (id, data) => {


### PR DESCRIPTION
on all tabs, sorting, ordering and pagination is broken because query params was not provided 

always pass params to fix issue (status is not provided when empty)

Log from backend 
`127.0.0.1 - - [25/Jun/2026 21:14:51] "GET /v1/books?sort_by=author&order=asc&offset=1 HTTP/1.1" 200 -`
