### PR TITLE
fix: do not escape sort by status in dropdown

### DIFF
--- a/web/src/components/SortSelector.jsx
+++ b/web/src/components/SortSelector.jsx
@@ -33,7 +33,7 @@ function SortSelector({sort, setSort, order, setOrder}) {
     const dropdownLabel = (
         <>
             <RiArrowUpDownLine className="h-4 w-4 mr-1"/>
-            <p>{t("sort.sort_by", {sortType: getSortName().toLowerCase()})}</p>
+            <p>{t("sort.sort_by", { interpolation: { escapeValue: false}, sortType: getSortName().toLowerCase()})}</p>
         </>
     )
 


### PR DESCRIPTION
In french, `date added` sort contains a quote which is escaped causing display of `&#39;` instead of `'`

<img width="477" height="66" alt="image" src="https://github.com/user-attachments/assets/c9f1f5a6-8213-4e72-83df-50b3d7f83b86" />

After fix
<img width="477" height="66" alt="image" src="https://github.com/user-attachments/assets/9e29e61f-e87e-4fa1-8d97-f4fd2a2c7812" />



