### PR TITLE
format rating

### DIFF
--- a/web/src/components/Library/BookRating.jsx
+++ b/web/src/components/Library/BookRating.jsx
@@ -39,6 +39,13 @@ function BookRating(props) {
         }
     }
 
+    const formatRating = () => {
+        if (props.rating) {
+            return Number.parseFloat(props.rating);
+        }
+        return "";
+    }
+
     useEffect(() => {
         if (rangeValue > 5) {
             setRatingErrorText(t("book.rating.error.greater_than"));
@@ -60,7 +67,7 @@ function BookRating(props) {
                 <RatingStar filled={Math.floor(props.rating) >= 3 ? true : false} />
                 <RatingStar filled={Math.floor(props.rating) >= 4 ? true : false} />
                 <RatingStar filled={Math.floor(props.rating) >= 5 ? true : false} />
-                <p className="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">{props.rating}</p>
+                <p className="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">{formatRating(props.rating)}</p>
             </Rating>
         )
     }


### PR DESCRIPTION
Do not display extra zero in book rating. It allows to have more space in the card
Before
<img width="192" height="77" alt="image" src="https://github.com/user-attachments/assets/11265824-6a98-4e99-9c73-2741dc156e9a" />
After
<img width="192" height="77" alt="image" src="https://github.com/user-attachments/assets/3288e21a-093d-4091-ae01-9ae1f9ce6297" />

<img width="192" height="77" alt="image" src="https://github.com/user-attachments/assets/6e580af6-2226-4e3f-9193-43040962d54f" />

What do you think about it ? 