### PR TITLE
fix: add padding on library for small screen to show pagination

### DIFF
--- a/web/src/pages/Library.jsx
+++ b/web/src/pages/Library.jsx
@@ -6,7 +6,7 @@ import AnimatedLayout from '../AnimatedLayout'
 function Library() {
   return (
     <AnimatedLayout>
-    <div className="container mx-auto ">
+    <div className="container mx-auto pb-15 md:pb-0">
       <LibraryPane />
       <WelcomeModal />
     </div>


### PR DESCRIPTION
On small screen pagination is hidden behind bottom tabs 

<img width="542" height="260" alt="image" src="https://github.com/user-attachments/assets/5db41a2e-fa88-4b0c-a392-c76361c2821c" />


this fix add padding to display pagination on small screens

<img width="542" height="260" alt="image" src="https://github.com/user-attachments/assets/359fc52a-735b-40c7-a841-6bc12d9b245d" />
