### PR TITLE
fix: remove tabs extra padding

### DIFF
--- a/web/src/components/BookTabs.jsx
+++ b/web/src/components/BookTabs.jsx
@@ -12,7 +12,7 @@ const BookTabs = ({ tabs, activeTab, onTabChange, children }) => {
     }, []);
 
     return (
-        <Tabs onActiveTabChange={onTabChange} variant={isMobile ? "fullWidth" : "underline"} className="pt-1">
+        <Tabs onActiveTabChange={onTabChange} variant={isMobile ? "fullWidth" : "underline"}>
             {tabs.map((tab) => (
                 <Tabs.Item key={tab.id} active={activeTab === tab.id} title={isMobile ? "" : tab.title} icon={tab.icon}>
                     <div className="pt-4">


### PR DESCRIPTION
remove extra padding on top of tabs on small screens

before

<img width="595" height="75" alt="image" src="https://github.com/user-attachments/assets/262cd905-93b8-4832-9a10-b4943d45399f" />

after

<img width="595" height="75" alt="image" src="https://github.com/user-attachments/assets/2112a235-7b46-4454-b558-98e77d836633" />
