### PR TITLE
fix: remove data folder for booklogr-db container

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -14,7 +14,7 @@ services:
         env_file:
             - .env
         volumes:
-            - ./booklogr:/var/lib/postgresql/data # persist data even if container shuts down
+            - ./booklogr:/var/lib/postgresql # persist data even if container shuts down
 
     booklogr-api:
         container_name: "booklogr-api"


### PR DESCRIPTION
When running lastest version of postgres db (18) in docker, there a error

```

Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).  This better reflects how
       PostgreSQL itself works, and how upgrades are to be performed.

       See also https://github.com/docker-library/postgres/pull/1259

       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)

       This is usually the result of upgrading the Docker image without
       upgrading the underlying database using "pg_upgrade" (which requires both
       versions).

       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory, allowing usage of "pg_upgrade --link" without mount point
       boundary issues.

       See https://github.com/docker-library/postgres/issues/37 for a (long)
       discussion around this process, and suggestions for how to do so.>
```

removing the data folder mapping in docker compose fix the issue