### PR TITLE
fix: change underline color on book title in dark mode

### DIFF
--- a/web/src/components/Library/BookItem.jsx
+++ b/web/src/components/Library/BookItem.jsx
@@ -23,7 +23,7 @@ function BookItem(props) {
 
                 />
                 <div className="flex flex-col p-4 leading-normal w-full">
-                <Link to={"/books/" + props.isbn} className="hover:underline">
+                <Link to={"/books/" + props.isbn} className="hover:underline dark:decoration-white">
                     <h5 className="mb-2 text font-bold tracking-tight text-gray-900 dark:text-white">{props.title}</h5>
                 </Link>
                 <p className="mb-3 font-normal text-gray-700 dark:text-gray-400 truncate">


### PR DESCRIPTION
In dark mode, hovering on title, the underline is black as in light mode

<img width="356" height="80" alt="image" src="https://github.com/user-attachments/assets/30b8a2f4-214f-42d5-8a0b-216e20be7ec0" />

this fix make the underline color in dark mode white like text

<img width="356" height="80" alt="image" src="https://github.com/user-attachments/assets/024eb9ca-47a7-46d0-adbe-41518a5d9ea4" />



