### PR TITLE
fix: book content overflow when author too long

### DIFF
--- a/web/src/components/Library/BookItem.jsx
+++ b/web/src/components/Library/BookItem.jsx
@@ -14,7 +14,7 @@ function BookItem(props) {
     const [imageLoaded, setImageLoaded] = useState(false);
     const theme = useThemeMode();
     const { t } = useTranslation();
-    
+
     return (
         <div className={`${props.view === "gallery" ? "flex-col min-h-full" : "min-w-full flex-row"} flex bg-white border border-gray-200 rounded-lg shadow md:flex-row md:max-w-md dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700`}>
                 <Img crossorigin="anonymous" className={`${props.view === "gallery" ? "w-full h-80" : "w-60 h-52"} object-cover  rounded-t-lg md:h-auto md:w-24 md:rounded-s-lg`} src={"https://covers.openlibrary.org/b/isbn/" + props.isbn + "-M.jpg?default=false"}
@@ -22,7 +22,7 @@ function BookItem(props) {
                     unloader={theme.mode == "dark" && <img className="object-fit h-56 w-full rounded-t-lg md:h-auto md:w-24 md:rounded-s-lg" src="/fallback-cover-light.svg"/> || theme.mode == "light" && <img className="object-fit h-56 w-full rounded-t-lg md:h-auto md:w-24 md:rounded-s-lg" src="/fallback-cover.svg"/>}
 
                 />
-                <div className="flex flex-col p-4 leading-normal w-full">
+                <div className="flex flex-col p-4 leading-normal w-full overflow-hidden">
                 <Link to={"/books/" + props.isbn} className="hover:underline">
                     <h5 className="mb-2 text font-bold tracking-tight text-gray-900 dark:text-white">{props.title}</h5>
                 </Link>


### PR DESCRIPTION
With current code, if author is too long, card content overflows

<img width="745" height="268" alt="image" src="https://github.com/user-attachments/assets/44e19b19-5632-4a81-b59e-563b991547e7" />

This commit fix the issue by adding 'overflow-hidden' class to card content div container

<img width="745" height="268" alt="image" src="https://github.com/user-attachments/assets/bdde98bd-0d35-4208-9fc0-796fb02908f9" />

