### PR TITLE
fix: add dark style for book rating description in modal

### DIFF
--- a/web/src/components/Library/BookRating.jsx
+++ b/web/src/components/Library/BookRating.jsx
@@ -81,11 +81,11 @@ function BookRating(props) {
                 {rating()}
             </Tooltip>
         )}
-        
+
         <Modal dismissible show={openModal} onClose={() => setOpenModal(false)}>
             <ModalHeader className="border-gray-200">{t("book.rating.rate_book")}</ModalHeader>
             <ModalBody>
-                <p>
+                <p className="dark:text-gray-200">
                     {t("book.rating.how_many_starts", {book_title: props.title})}
                 </p>
                 <div className="flex flex-row items-center gap-4">
@@ -94,13 +94,11 @@ function BookRating(props) {
                     </div>
                     <div className="basis-2/12">
                         <TextInput type="number" min={0} max={5} step={0.5} value={rangeValue} onChange={(e) => setRangeValue(e.target.value)} color={ratingErrorText ? 'failure' : 'gray'} />
-                        
                     </div>
-                    
                 </div>
                 <span className="text-red-600 text-sm">
-                            {ratingErrorText}
-                        </span>
+                    {ratingErrorText}
+                </span>
             </ModalBody>
             <ModalFooter>
             <Button onClick={() => handleRateBook()} disabled={saveButtonDisabled}>{t("forms.save")}</Button>


### PR DESCRIPTION
Add dark style for explanation in book rating modal

<img width="653" height="283" alt="image" src="https://github.com/user-attachments/assets/1dbae826-3847-455a-b274-7bdf9400e89b" />
