### PR TITLE
fix: correct typo in translation key for book rating

### DIFF
--- a/web/src/components/Library/BookRating.jsx
+++ b/web/src/components/Library/BookRating.jsx
@@ -81,12 +81,12 @@ function BookRating(props) {
                 {rating()}
             </Tooltip>
         )}
-        
+
         <Modal dismissible show={openModal} onClose={() => setOpenModal(false)}>
             <ModalHeader className="border-gray-200">{t("book.rating.rate_book")}</ModalHeader>
             <ModalBody>
                 <p>
-                    {t("book.rating.how_many_starts", {book_title: props.title})}
+                    {t("book.rating.how_many_stars", {book_title: props.title})}
                 </p>
                 <div className="flex flex-row items-center gap-4">
                     <div className="basis-10/12">
@@ -94,9 +94,9 @@ function BookRating(props) {
                     </div>
                     <div className="basis-2/12">
                         <TextInput type="number" min={0} max={5} step={0.5} value={rangeValue} onChange={(e) => setRangeValue(e.target.value)} color={ratingErrorText ? 'failure' : 'gray'} />
-                        
+
                     </div>
-                    
+
                 </div>
                 <span className="text-red-600 text-sm">
                             {ratingErrorText}


### PR DESCRIPTION
fix typo in key (not translated in other language than en-GB)