### PR TITLE
Add dark mode hover effect to edition selector modal

### DIFF
--- a/web/src/components/EditionSelector.jsx
+++ b/web/src/components/EditionSelector.jsx
@@ -113,7 +113,7 @@ function EditionSelector({work_id, selected_isbn}) {
                     return (
                         data.isbn_13?.[0] && (
                             <Link key={data.isbn_13[0]} to={"/books/" + data.isbn_13[0]} className="contents">
-                                <div className="flex w-full hover:bg-gray-100">
+                                <div className="flex w-full hover:bg-gray-100 hover:dark:bg-gray-600">
                                     <EditionItem data={data} selected_isbn={selected_isbn} />
                                 </div>
                             </Link>


### PR DESCRIPTION
Add dark mode missing class for edition hover in edition selector 

<img width="661" height="353" alt="image" src="https://github.com/user-attachments/assets/3a204270-8b04-4748-ab3f-688549ea5f65" />


Fix #163 